### PR TITLE
Fix for updating internal state from props after initial render

### DIFF
--- a/lib/SimpleRadioButton.js
+++ b/lib/SimpleRadioButton.js
@@ -29,6 +29,12 @@ var RadioForm = React.createClass({
       labelColor: '#000'
     }
   },
+  
+  componentWillReceiveProps: function(nextProps) {
+    this.setState({
+      is_active_index: nextProps.initial
+    });
+  },
 
   _renderButton: function (obj, i) {
     return (


### PR DESCRIPTION
Fixes an issue with the 'initial' prop - in our app we have multiple subviews that use the radio button component to set a property for different users. The issue we encountered was that even when passing in new props, the initially selected button would be whatever the last selection (made on a different subview) had been.

This fix allows the radio button component to respond to updates passed in to the 'initial' prop.