### PR TITLE
customizable buttonOuterSize

### DIFF
--- a/lib/SimpleRadioButton.js
+++ b/lib/SimpleRadioButton.js
@@ -45,6 +45,7 @@ var RadioForm = React.createClass({
         index={i}
         buttonColor={this.props.buttonColor}
         buttonSize={this.props.buttonSize}
+        buttonOuterSize={this.props.buttonOuterSize}
         labelHorizontal={this.props.labelHorizontal}
         labelColor={this.props.labelColor}
         labelStyle={this.props.labelStyle}
@@ -140,6 +141,11 @@ export class RadioButtonInput extends React.Component {
       outerSize.width = this.props.buttonSize + 10
       outerSize.height = this.props.buttonSize + 10
       outerSize.borderRadius = (this.props.buttonSize + 10) / 2
+    }
+    if (this.props.buttonOuterSize) {
+      outerSize.width = this.props.buttonOuterSize
+      outerSize.height = this.props.buttonOuterSize
+      outerSize.borderRadius = this.props.buttonOuterSize / 2
     }
     var outerColor = this.props.buttonOuterColor
     var borderWidth = this.props.borderWidth || 3


### PR DESCRIPTION
now it is possible to fix:
https://github.com/moschan/react-native-simple-radio-button/issues/32

buttonSize={18}
buttonOuterSize={30}
works best for real device (for me)