### PR TITLE
support disabled mode

### DIFF
--- a/lib/SimpleRadioButton.js
+++ b/lib/SimpleRadioButton.js
@@ -200,7 +200,8 @@ export class RadioButtonInput extends React.Component {
 
 RadioButtonInput.defaultProps = {
   buttonInnerColor: '#2196f3',
-  buttonOuterColor: '#2196f3'
+  buttonOuterColor: '#2196f3',
+  disabled: false
 }
 
 export class RadioButtonLabel extends React.Component {

--- a/lib/SimpleRadioButton.js
+++ b/lib/SimpleRadioButton.js
@@ -28,7 +28,7 @@ var RadioForm = React.createClass({
       labelHorizontal: true,
       animation: true,
       labelColor: '#000',
-	  disabled: false,
+      disabled: false
     }
   },
 
@@ -52,11 +52,10 @@ var RadioForm = React.createClass({
         labelStyle={this.props.labelStyle}
         style={this.props.radioStyle}
         animation={this.props.animation}
+		disabled={this.props.disabled}
         onPress={(value, index) => {
-		  if (!this.props.disabled) {
-			  this.props.onPress(value, index)
-	          this.setState({is_active_index: index})
-		  }
+			this.props.onPress(value, index)
+			this.setState({is_active_index: index})
         }}
       />
     )
@@ -89,7 +88,8 @@ var RadioButton = React.createClass({
     return {
       isSelected: false,
       buttonColor: '#2196f3',
-      labelHorizontal: true
+      labelHorizontal: true,
+      disabled: false,
     }
   },
   componentWillUpdate () {
@@ -157,26 +157,41 @@ export class RadioButtonInput extends React.Component {
       outerColor = this.props.buttonColor
       innerColor = this.props.buttonColor
     }
+	var c = (
+		<View style={[
+		  Style.radioNormal,
+		  this.props.isSelected && Style.radioActive,
+		  this.props.isSelected && innerSize,
+		  this.props.isSelected && {backgroundColor:innerColor}
+		]}></View>
+	)
+	var radioStyle = [
+	  Style.radio,
+	  {
+		borderColor:outerColor,
+		borderWidth:borderWidth
+	  },
+	  this.props.buttonStyle,
+	  outerSize
+  	]
+
+	if (this.props.disabled) {
+		return (
+	      <View style={this.props.buttonWrapStyle} >
+	        <View style={radioStyle}>
+	          {c}
+	  		</View>
+	      </View>
+	    )
+	}
+
     return (
       <View style={this.props.buttonWrapStyle} >
         <TouchableOpacity
-          style={[
-            Style.radio,
-            {
-              borderColor:outerColor,
-              borderWidth:borderWidth
-            },
-            this.props.buttonStyle,
-            outerSize
-          ]}
+          style={radioStyle}
           onPress={() => { this.props.onPress( this.props.obj.value, this.props.index) }
           }>
-          <View style={[
-            Style.radioNormal,
-            this.props.isSelected && Style.radioActive,
-            this.props.isSelected && innerSize,
-            this.props.isSelected && {backgroundColor:innerColor}
-          ]}></View>
+         {c}
         </TouchableOpacity>
       </View>
     )

--- a/lib/SimpleRadioButton.js
+++ b/lib/SimpleRadioButton.js
@@ -27,7 +27,8 @@ var RadioForm = React.createClass({
       formHorizontal: false,
       labelHorizontal: true,
       animation: true,
-      labelColor: '#000'
+      labelColor: '#000',
+	  disabled: false,
     }
   },
 
@@ -52,8 +53,10 @@ var RadioForm = React.createClass({
         style={this.props.radioStyle}
         animation={this.props.animation}
         onPress={(value, index) => {
-          this.props.onPress(value, index)
-          this.setState({is_active_index: index})
+		  if (!this.props.disabled) {
+			  this.props.onPress(value, index)
+	          this.setState({is_active_index: index})
+		  }
         }}
       />
     )

--- a/lib/SimpleRadioButton.js
+++ b/lib/SimpleRadioButton.js
@@ -215,7 +215,11 @@ export class RadioButtonLabel extends React.Component {
   render () {
     return (
       <TouchableWithoutFeedback
-        onPress={() => {this.props.onPress( this.props.obj.value, this.props.index)}}>
+        onPress={() => {
+			if (!this.props.disabled) {
+				this.props.onPress( this.props.obj.value, this.props.index)}
+			}
+		}>
         <View style={[
           this.props.labelWrapStyle,
           Style.labelWrapStyle,


### PR DESCRIPTION
Disabled prop added to RadioForm, RadioButton, RadioButtonInput, RadioButtonLabel. 
When disabled, radio button is wrapped in View instead of TouchableOpacity. RadioButtonLabel onPress does nothing when disabled. 