### PR TITLE
Show Labels that support React-Native ^0.36

### DIFF
--- a/lib/Style.js
+++ b/lib/Style.js
@@ -9,7 +9,7 @@ var Style = StyleSheet.create({
   },
 
   radioWrap: {
-    flex: 1,
+    flexGrow: 1,
     flexDirection: 'row',
     alignItems: 'center',
     alignSelf: 'center',
@@ -45,7 +45,7 @@ var Style = StyleSheet.create({
   },
 
   labelWrapStyle: {
-    flex: 1,
+    flexGrow: 1,
     flexDirection: 'row',
     alignItems: 'center',
     alignSelf: 'center'


### PR DESCRIPTION
Resolve the problem in #35

> Removing the bad flex: 1 style or changing it to flexGrow: 1

Ref: https://github.com/facebook/react-native/releases/tag/v0.36.0