### PR TITLE
Add support for styles on radiobutton wrapper and clarify documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,30 +86,34 @@ Pro
   formHorizontal={true}
   animation={true}
 >
-  <RadioButton labelHorizontal={true} key={i} >
-    {/*  You can set RadioButtonLabel before RadioButtonInput */}
-    <RadioButtonInput
-      obj={obj}
-      index={i}
-      isSelected={this.state.value3Index === i}
-      onPress={onPress}
-      borderWidth={1}
-      buttonInnerColor={'#e74c3c'}
-      buttonOuterColor={this.state.value3Index === i ? '#2196f3' : '#000'}
-      buttonSize={40}
-      buttonOuterSize={80}
-      buttonStyle={{}}
-      buttonWrapStyle={{marginLeft: 10}}
-    />
-    <RadioButtonLabel
-      obj={obj}
-      index={i}
-      labelHorizontal={true}
-      onPress={onPress}
-      labelStyle={{fontSize: 20, color: '#2ecc71'}}
-      labelWrapStyle={{}}
-    />
-  </RadioButton>
+  {/* To create radio buttons, loop through your array of options */}
+  {radio_props.map((obj, i) => {
+    <RadioButton labelHorizontal={true} key={i} >
+      {/*  You can set RadioButtonLabel before RadioButtonInput */}
+      <RadioButtonInput
+        obj={obj}
+        index={i}
+        isSelected={this.state.value3Index === i}
+        onPress={onPress}
+        borderWidth={1}
+        buttonInnerColor={'#e74c3c'}
+        buttonOuterColor={this.state.value3Index === i ? '#2196f3' : '#000'}
+        buttonSize={40}
+        buttonOuterSize={80}
+        buttonStyle={{}}
+        buttonWrapStyle={{marginLeft: 10}}
+      />
+      <RadioButtonLabel
+        obj={obj}
+        index={i}
+        labelHorizontal={true}
+        onPress={onPress}
+        labelStyle={{fontSize: 20, color: '#2ecc71'}}
+        labelWrapStyle={{}}
+      />
+      </RadioButton>
+  })}
+  
 </RadioForm>
 ```
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ The label color
 ### style
 The label style
 
+### wrapStyle
+Styles that are applied to the <View> wrapping the RadioButton component.
+
 ## onPress _*required_
 callback when radio button clicked.
 

--- a/lib/SimpleRadioButton.js
+++ b/lib/SimpleRadioButton.js
@@ -154,7 +154,7 @@ export class RadioButton extends React.Component {
       </View>
     )
     return (
-      <View>
+      <View style={this.props.wrapStyle}>
         {renderContent}
       </View>
     )


### PR DESCRIPTION
I wanted to create a grid layout with set widths on the radio buttons, but due to a missing style attribute on the RadioButton's wrapper Views, I couldn't.

This fixes that missing style attribute and documents it.

This also adds documentation clarification requested in https://github.com/moschan/react-native-simple-radio-button/issues/60