### PR TITLE
Fixed typo for word 'radio'

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ radio button value and label array
 callback when radio button clicked.
 
 ### initial (Default: `0`)
-The index of selected raio button. This is used when this component is activated. If you want to
+The index of selected radio button. This is used when this component is activated. If you want to
 pass initial as asynchronous, you can use updateIsActiveIndex function.
 > If you want to make it empty initially, please pass `-1`
 


### PR DESCRIPTION
Updated README to fix typo for word `radio` from 'raio'