### PR TITLE
Pass value, not object, to onPress in updateIsActiveIndex

### DIFF
--- a/lib/SimpleRadioButton.js
+++ b/lib/SimpleRadioButton.js
@@ -41,7 +41,7 @@ export default class RadioForm extends React.Component {
 
   updateIsActiveIndex(index) {
     this.setState({ is_active_index: index });
-    this.props.onPress(this.props.radio_props[index], index)
+    this.props.onPress(this.props.radio_props[index].value, index)
   }
 
   _renderButton(obj, i) {


### PR DESCRIPTION
This caused issues in my `onPress` handlers that were expecting the value of the button, not the button object.