### PR TITLE
Fixed _this7.props.onPress is not a function

### DIFF
--- a/lib/SimpleRadioButton.js
+++ b/lib/SimpleRadioButton.js
@@ -266,7 +266,7 @@ export class RadioButtonLabel extends React.Component {
         accessibilityLabel={this.props.accessibilityLabel}
         testID={this.props.testID}
         onPress={() => {
-        if (!this.props.disabled) {
+        if (this.props.onPress && !this.props.disabled) {
           this.props.onPress( this.props.obj.value, this.props.index)}
         }
       }>


### PR DESCRIPTION
Spamming the radio buttons constantly resulted in a "_this7.props.onPress is not a function" error. I've added a single condition to check if the onPress function exists before calling it.