### PR TITLE
update RadioButtonInput accessibility label 

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ indicates accessibility for the individual radio button input and radio button l
 
 ### accessibilityLabel
 used to set accessibilityLabel for individual radio button input and radio button label components,
-radio button input will have accessibilityLabel = [accessibilityLabel]Input[index]
+radio button input will have accessibilityLabel = [accessibilityLabel]Radio Button[index]
 radio button label will have accessibilityLabel = [accessibilityLabel]Label[index]
 
 ### testID

--- a/lib/SimpleRadioButton.js
+++ b/lib/SimpleRadioButton.js
@@ -155,7 +155,7 @@ export class RadioButton extends React.Component {
         !this.props.labelHorizontal && Style.labelVerticalWrap
       ]}>
         <RadioButtonInput {...this.props}
-          accessibilityLabel={accessibilityLabel + 'Input' + accessibilityLabelIndex}
+          accessibilityLabel={accessibilityLabel + 'Radio Button' + accessibilityLabelIndex}
           testID={testID + 'Input' + testIDIndex} />
         <RadioButtonLabel {...this.props}
           accessibilityLabel={accessibilityLabel + 'Label' + accessibilityLabelIndex}


### PR DESCRIPTION
To improve screen reader clarity. Changing from 'input' to 'radio button' will provide screen readers with more descriptive and helpful narration.